### PR TITLE
Return reasons

### DIFF
--- a/src/js/components/actionbox/Returned.js
+++ b/src/js/components/actionbox/Returned.js
@@ -4,6 +4,15 @@ const Icon = require('../Icon')
 const Returned = ({ actionBox }) => {
   if (!actionBox.label) return null
 
+  let iconName = 'return'
+
+  // custom icons for some return reasons
+  if (actionBox.type === 'returned-AddressIssue') {
+    iconName = 'questionmark'
+  } else if (actionBox.type === 'returned-NotColleccted') {
+    iconName = 'not_delivered'
+  }
+
   return html`
     <div class="pl-box pl-action-box pl-box-icon-status">
       <div class="pl-box-heading">
@@ -11,7 +20,7 @@ const Returned = ({ actionBox }) => {
       </div>
 
       <div class="pl-box-body">
-        ${ Icon('return', null, '80') }
+        ${ Icon(iconName, null, '80') }
       </div>
 
       <div class="pl-box-footer">

--- a/src/js/components/actionbox/index.js
+++ b/src/js/components/actionbox/index.js
@@ -44,7 +44,7 @@ const ActionBox = ({ checkpoints, activeTracking, query, options }, emit) => {
       result = NextAction(tHeader)
     }
 
-    if (type.startsWith('returned')) {
+    if (type.indexOf('returned') === 0) {
       result = Returned(tHeader)
     }
 

--- a/src/js/components/actionbox/index.js
+++ b/src/js/components/actionbox/index.js
@@ -44,7 +44,7 @@ const ActionBox = ({ checkpoints, activeTracking, query, options }, emit) => {
       result = NextAction(tHeader)
     }
 
-    if (type === 'returned') {
+    if (type.startsWith('returned')) {
       result = Returned(tHeader)
     }
 


### PR DESCRIPTION
We want to begin showing custom icons for the t&t page for different returns
see this backend issue:
https://github.com/parcelLab/Backend/issues/1175