### PR TITLE
Enable recently added translations

### DIFF
--- a/src/js/lib/static.js
+++ b/src/js/lib/static.js
@@ -328,7 +328,7 @@ const languages = {
   },
   eu: {
     name: 'eu',
-    label: 'Euskal Herria',
+    label: 'Euskara',
     code: 'BAQ',
     icon: 'https://cdn.parcellab.com/img/flags/basque.png'
   },


### PR DESCRIPTION
Enable translations added via this commit: https://github.com/parcelLab/parcelLab-js-plugin/commit/f413c15e3561b3180106a4f86337ea3b7c6dbcf3#diff-8b2213a6b26be7eb98dfae8bbdcb489765848d30f9584f37169a0f5a114a6d93

Since the flags for galicia and basque country were missing from out S3 bucket, I've generated 16x11 png imgs for them. Please let me know if they don't look too good!