### PR TITLE
#289/fix-zip-component-V3

### DIFF
--- a/src/scss/actionBox.scss
+++ b/src/scss/actionBox.scss
@@ -533,6 +533,7 @@ h3 {
     // height:50px;
     background-color:#f5f5f5;
     padding-right: 44px;
+    color: #000;
     // font-size:21px;
   }
   .pl-force-zip-input-submit {


### PR DESCRIPTION
In our hosted websites, the zip's input colour is affected due to the imported bootstrap css messing with the styles applied to the component. It changes its default color to inherit, which picks the white colour from the parent component.

This happens on both V5 and V3 hosted versions.

A PR has already been created for the T&T V5 (https://github.com/parcelLab/parcellab-trackandtrace-plugin/pull/316) and this aims to replicate to the current live version V3.