### PR TITLE
add class to checkpoint status details

### DIFF
--- a/src/js/components/Checkpoint.js
+++ b/src/js/components/Checkpoint.js
@@ -5,7 +5,7 @@ const Checkpoint = cp => html`
   <div class="pl-checkpoint ${ cp.alert ? `pl-${cp.alert}` : '' }">
     <div><small>${ cp.dateText}  ${cp.locationText }</small></div>
     <div><b>${ cp.status_text}</b></div>
-    <div>${ raw(cp.status_details) }</div>
+    <div class="pl-checkpoint-status-details">${ raw(cp.status_details) }</div>
   </div>
 `
 


### PR DESCRIPTION
This small fix is so that we/our customers can change the texts of the checkpoint status details using onRendered functions, without affecting the other children of the "pl-checkpoint" class. The change was requested by Matt for Aldi UK.

<img width="490" alt="Screenshot 2022-02-10 at 14 21 03" src="https://user-images.githubusercontent.com/48354305/153416586-23fbc27e-2880-46f6-89ad-1cff952ce42d.png">
