### PR TITLE
Fixed client string definition in options

### DIFF
--- a/src/js/parcelLab.js
+++ b/src/js/parcelLab.js
@@ -58,7 +58,7 @@ class ParcelLab {
     this.client =
       this.getUrlQuery('client') ||
       this.getUrlQuery('shop') ||
-      this.options.secureHash
+      this.options.client
     this.zip = this.getUrlQuery('zip') || this.options.zip
 
     // get note fron url


### PR DESCRIPTION
This was "secureHash" which looks like a copy/paste error.

Without this fix, the user is unable to define the securityHash in the options.