### PR TITLE
fix address for GBR

### DIFF
--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -14,11 +14,14 @@ const Address = (deliveryInfo, lang) => {
             `
           : ''}
         <p>${raw(deliveryInfo.street)}</p>
-        <p>
-          ${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}
-          <br>
+        ${deliveryInfo.destination_country_iso3 &&
+          deliveryInfo.destination_country_iso3 === 'GBR'
+            ? html`<p>
+                ${raw(deliveryInfo.city)} <br>
+                ${deliveryInfo.zip_code}
+              </p>`
+            : html`<p>${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}</p>`}
           ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
-        </p>
       </address>
     `
 }


### PR DESCRIPTION
This is a small PR to fix address format for GBR.  Earlier we have address in the format 

> Name
Address
BN23 5BU Eastbourne East Sussex
United Kingdom

But now I add a check for GBR country address to make the address format as 

> Name
Address
Eastbourne East Sussex
BN23 5BU
United Kingdom

This issue can be tested using the URL :- http://localhost:4000/?lang=en&u=1613945&orderNo=42735746510&s=HpTfcBw1q9

For non-GBR address, this URL is http://localhost:4000/?orderNo=29058975403&show_articleList=yes&lang=en&pwrdBy_parcelLab=hide&s=VP6i4kHRBF&u=1613594

More info for this issue can be found here https://app.zenhub.com/workspaces/b2c-inbound-60fead87156f570012d5e43d/issues/parcellab/parcellab-trackandtrace-plugin/633