### PR TITLE
Added USA format city state and zipcode

### DIFF
--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -35,7 +35,6 @@ const Address = (deliveryInfo, lang) => {
 
 module.exports = function DeliveryAddress (tHeader, lang, options) {
   const { delivery_info: deliveryInfo } = tHeader
-  console.log(deliveryInfo)
   if (
     deliveryInfo &&
     deliveryInfo.street &&

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -28,8 +28,9 @@ const Address = (deliveryInfo, lang) => {
         <p>
           ${cityLine}
         </p>
-          ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
-          ? '' : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
+          ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA'))
+          ? '' 
+          : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `
 }

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -5,6 +5,17 @@ const { translate } = require('../../lib/translator.js')
 
 const Address = (deliveryInfo, lang) => {
   const translatedDestinationCountryName = translate('countryName', lang)[deliveryInfo.destination_country_iso3]
+  const cityLine = 
+    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for Great Britian
+      ? html`
+          ${raw(deliveryInfo.city)} <br>
+          ${deliveryInfo.zip_code}
+        `
+      : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
+      ? html`
+        ${raw(deliveryInfo.city)}${(delivery_info.region && delivery_info.region.indexOf('-') > -1) ? `, ${delivery_info.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
+      `
+      : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}` // Otherwise format
 
     return html`
       <address>
@@ -15,14 +26,8 @@ const Address = (deliveryInfo, lang) => {
           : ''}
         <p>${raw(deliveryInfo.street)}</p>
         <p>
-        ${deliveryInfo.destination_country_iso3 &&
-          deliveryInfo.destination_country_iso3 === 'GBR'
-            ? html`
-                ${raw(deliveryInfo.city)} <br>
-                ${deliveryInfo.zip_code}
-              `
-            : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`}
-            </p>
+          ${cityLine}
+        </p>
           ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -13,7 +13,7 @@ const Address = (deliveryInfo, lang) => {
         `
       : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
       ? html`
-        ${raw(deliveryInfo.city)}${(delivery_info.region && delivery_info.region.indexOf('-') > -1) ? `, ${delivery_info.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
+        ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
       `
       : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}` // Otherwise format
 
@@ -34,7 +34,7 @@ const Address = (deliveryInfo, lang) => {
 }
 
 module.exports = function DeliveryAddress (tHeader, lang, options) {
-  const { delivery_info: deliveryInfo } = tHeader
+  const { deliveryInfo: deliveryInfo } = tHeader
   if (
     deliveryInfo &&
     deliveryInfo.street &&

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -10,12 +10,12 @@ const Address = (deliveryInfo, lang) => {
   const regex = new RegExp(`(^|[^a-zA-Z])${regionCode}([^a-zA-Z]|$)`, 'g')
   const formatCityLine = () => {
     switch (deliveryInfo.destination_country_iso3) {
-      case "GBR":
+      case 'GBR':
         return html`
           ${raw(deliveryInfo.city)} <br />
           ${deliveryInfo.zip_code}
         `
-      case "USA":
+      case 'USA':
         if (deliveryInfo.city.search(regex) !== -1) {
           // Trust vendor's data
           return html` ${raw(deliveryInfo.city)} ${deliveryInfo.zip_code.substring(0, 5)} `
@@ -28,11 +28,11 @@ const Address = (deliveryInfo, lang) => {
         return html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`
     }
   }
-  
+
   const formatCountryLine = () => {
-    if (deliveryInfo.destination_country_iso3 === "USA") return ""
+    if (deliveryInfo.destination_country_iso3 === 'USA') return ''
     switch (deliveryInfo.destination_country_iso3) {
-      case "USA":
+      case 'USA':
         return ''
       default:
         return translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -5,6 +5,18 @@ const { translate } = require('../../lib/translator.js')
 
 const Address = (deliveryInfo, lang) => {
   const translatedDestinationCountryName = translate('countryName', lang)[deliveryInfo.destination_country_iso3]
+  const cityLine = 
+    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for Great Britian
+      ? html`
+          ${raw(deliveryInfo.city)} <br>
+          ${deliveryInfo.zip_code}
+        `
+      : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
+      ? html`
+        ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
+      `
+      : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}` // Otherwise format
+
     return html`
       <address>
         ${deliveryInfo.recipient
@@ -14,19 +26,8 @@ const Address = (deliveryInfo, lang) => {
           : ''}
         <p>${raw(deliveryInfo.street)}</p>
         <p>
-          ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) ? '' : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
-        ${deliveryInfo.destination_country_iso3 &&
-          deliveryInfo.destination_country_iso3 === 'GBR' // Great Britain Formatting
-            ? html`
-                ${raw(deliveryInfo.city)} <br>
-                ${deliveryInfo.zip_code}
-              `
-            : deliveryInfo.destination_country_iso3 &&
-            deliveryInfo.destination_country_iso3 === 'USA' // USA Formatting
-            ? html`
-              ${raw(deliveryInfo.city)}${deliveryInfo.region} ${deliveryInfo.zip_code}
-            ` : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`}
-            </p>
+          ${cityLine}
+        </p>
           ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `
@@ -34,6 +35,7 @@ const Address = (deliveryInfo, lang) => {
 
 module.exports = function DeliveryAddress (tHeader, lang, options) {
   const { delivery_info: deliveryInfo } = tHeader
+  console.log(deliveryInfo)
   if (
     deliveryInfo &&
     deliveryInfo.street &&

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -5,18 +5,6 @@ const { translate } = require('../../lib/translator.js')
 
 const Address = (deliveryInfo, lang) => {
   const translatedDestinationCountryName = translate('countryName', lang)[deliveryInfo.destination_country_iso3]
-  const cityLine = 
-    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for Great Britian
-      ? html`
-          ${raw(deliveryInfo.city)} <br>
-          ${deliveryInfo.zip_code}
-        `
-      : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
-      ? html`
-        ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
-      `
-      : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}` // Otherwise format
-
     return html`
       <address>
         ${deliveryInfo.recipient
@@ -26,9 +14,20 @@ const Address = (deliveryInfo, lang) => {
           : ''}
         <p>${raw(deliveryInfo.street)}</p>
         <p>
-          ${cityLine}
-        </p>
           ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) ? '' : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
+        ${deliveryInfo.destination_country_iso3 &&
+          deliveryInfo.destination_country_iso3 === 'GBR' // Great Britain Formatting
+            ? html`
+                ${raw(deliveryInfo.city)} <br>
+                ${deliveryInfo.zip_code}
+              `
+            : deliveryInfo.destination_country_iso3 &&
+            deliveryInfo.destination_country_iso3 === 'USA' // USA Formatting
+            ? html`
+              ${raw(deliveryInfo.city)}${deliveryInfo.region} ${deliveryInfo.zip_code}
+            ` : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`}
+            </p>
+          ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `
 }

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -28,7 +28,8 @@ const Address = (deliveryInfo, lang) => {
         <p>
           ${cityLine}
         </p>
-          ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
+          ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
+          ? '' : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `
 }

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -33,7 +33,7 @@ const Address = (deliveryInfo, lang) => {
 }
 
 module.exports = function DeliveryAddress (tHeader, lang, options) {
-  const { deliveryInfo: deliveryInfo } = tHeader
+  const { delivery_info: deliveryInfo } = tHeader
   if (
     deliveryInfo &&
     deliveryInfo.street &&

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -13,7 +13,7 @@ const Address = (deliveryInfo, lang) => {
         `
       : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA
       ? html`
-        ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code}
+        ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code.substring(0, 5)}
       `
       : html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}` // Otherwise format
 

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -14,29 +14,30 @@ const Address = (deliveryInfo, lang) => {
         return html`
           ${raw(deliveryInfo.city)} <br />
           ${deliveryInfo.zip_code}
-        `;
+        `
       case "USA":
         if (deliveryInfo.city.search(regex) !== -1) {
           // Trust vendor's data
-          return html` ${raw(deliveryInfo.city)} ${deliveryInfo.zip_code.substring(0, 5)} `;
+          return html` ${raw(deliveryInfo.city)} ${deliveryInfo.zip_code.substring(0, 5)} `
          }  else {
          // Use our region data
          return html`
             ${raw(deliveryInfo.city)}${(deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? `, ${deliveryInfo.region.split('-')[1]}`: ''} ${deliveryInfo.zip_code.substring(0, 5)}`
          }
       default:
-        return html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`;
+        return html`${deliveryInfo.zip_code} ${raw(deliveryInfo.city)}`
     }
-  };
+  }
+  
   const formatCountryLine = () => {
-    if (deliveryInfo.destination_country_iso3 === "USA") return "";
+    if (deliveryInfo.destination_country_iso3 === "USA") return ""
     switch (deliveryInfo.destination_country_iso3) {
       case "USA":
-        return '';
+        return ''
       default:
-        return translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3;
+        return translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3
     }
-  };
+  }
 
   return html`
     <address>

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -6,7 +6,7 @@ const { translate } = require('../../lib/translator.js')
 const Address = (deliveryInfo, lang) => {
   const translatedDestinationCountryName = translate('countryName', lang)[deliveryInfo.destination_country_iso3]
   const cityLine = 
-    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for Great Britian
+    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for United Kingdom
       ? html`
           ${raw(deliveryInfo.city)} <br>
           ${deliveryInfo.zip_code}

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -28,7 +28,7 @@ const Address = (deliveryInfo, lang) => {
         <p>
           ${cityLine}
         </p>
-          ${translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
+          ${(deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) ? '' : translatedDestinationCountryName ? translatedDestinationCountryName : deliveryInfo.destination_country_iso3}
       </address>
     `
 }

--- a/src/js/components/actionbox/DeliveryAddress.js
+++ b/src/js/components/actionbox/DeliveryAddress.js
@@ -5,10 +5,9 @@ const { translate } = require('../../lib/translator.js')
 
 const Address = (deliveryInfo, lang) => {
   const translatedDestinationCountryName = translate('countryName', lang)[deliveryInfo.destination_country_iso3]
-  const cityLine = 
-    (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'GBR')) // Format for United Kingdom
-      ? html`
-          ${raw(deliveryInfo.city)} <br>
+
+  const regionCode = (deliveryInfo.region && deliveryInfo.region.indexOf('-') > -1) ? deliveryInfo.region.split('-')[1] : 'REGION_CODE'
+  const regex = new RegExp(`(^|[^a-zA-Z])${regionCode}([^a-zA-Z]|$)`, 'g')
           ${deliveryInfo.zip_code}
         `
       : (deliveryInfo.destination_country_iso3 && (deliveryInfo.destination_country_iso3 === 'USA')) // Format for USA


### PR DESCRIPTION
Added case for USA addresses that will parse the state code from the region field like we do in the placeholders for {{region/state}} and append it to the city when it exists.

This is a fix for Ikea but also all US customers.
