### PR TITLE
feat: add support for the query string parameter `plUserId` [TT-85]

### DIFF
--- a/src/js/parcelLab.js
+++ b/src/js/parcelLab.js
@@ -50,7 +50,7 @@ class ParcelLab {
       this.getUrlQuery('c') ||
       this.options.courier
     this.userId =
-      this.getUrlQuery('plUserId') || this.getUrlQuery('userId') || this.getUrlQuery('u') || this.options.userId
+      this.getUrlQuery('plUserId') || this.getUrlQuery('u') || this.getUrlQuery('userId') || this.options.userId
     this.secureHash =
       this.getUrlQuery('s') ||
       this.getUrlQuery('secureHash') ||

--- a/src/js/parcelLab.js
+++ b/src/js/parcelLab.js
@@ -50,7 +50,7 @@ class ParcelLab {
       this.getUrlQuery('c') ||
       this.options.courier
     this.userId =
-      this.getUrlQuery('u') || this.getUrlQuery('userId') || this.options.userId
+      this.getUrlQuery('plUserId') || this.getUrlQuery('userId') || this.getUrlQuery('u') || this.options.userId
     this.secureHash =
       this.getUrlQuery('s') ||
       this.getUrlQuery('secureHash') ||

--- a/src/js/parcelLab.js
+++ b/src/js/parcelLab.js
@@ -217,6 +217,8 @@ class ParcelLab {
       if (!opts[key]) opts[key] = DEFAULT_OPTS[key]
     })
 
+    if(opts.plUserId) opts.userId = opts.plUserId
+
     if (opts.show_searchForm && !opts.userId) {
       console.error(
         '⚠️  You must pass your userId in the options if you want to display a searchForm!'


### PR DESCRIPTION
This PR adds support for the query string parameter `plUserId` to receive the value of "user id".

It also changes the priority order of the user id parameters.
Now the code will try to get the user id first from `plUserId`, then from `u`, and last from `userId`.

#### Example:
https://delivery-status.com/?orderNo=00PL004&lang=en&u=0000&plUserId=1612197


#### Screenshot of the example before the change:
![screenshot](https://www.evernote.com/l/AsGtFhVgN0dNbIy7U4AYkDLk-cm4bWVwQkUB/image.png)