### PR TITLE
TT-174/fix-no-action-box-for-unknow-pickup-location

### DIFF
--- a/src/js/components/actionbox/PickupLocationUnknown.js
+++ b/src/js/components/actionbox/PickupLocationUnknown.js
@@ -28,23 +28,6 @@ const PickupLocationUnknown = ({ actionBox, courier, last_delivery_status }, lan
       </div>
     </div>
   `
-
-  // return html`
-  //   <div class="pl-box pl-action-box pl-box-pseudo-map">
-  //     <div class="pl-box-body">
-  //       <div id="pl-pseudo-map">
-  //         <a href="${courier.trackingurl}" title="${actionBox.label}" target="_blank">          
-  //           <div class="pl-pseudo-map-text">
-  //             <span>
-  //               ${ status }
-  //               ${ actionBox.label }
-  //             </span>
-  //           </div>
-  //         </a>
-  //       </div>
-  //     </div>
-  //   </div>
-  // `
 }
 
 module.exports = PickupLocationUnknown

--- a/src/js/components/actionbox/PickupLocationUnknown.js
+++ b/src/js/components/actionbox/PickupLocationUnknown.js
@@ -2,8 +2,6 @@ const html = require('nanohtml')
 const { translate } = require('../../../js/lib/translator.js')
 
 const PickupLocationUnknown = ({ actionBox, courier, last_delivery_status }, lang) => {
-  if (!courier || !courier.trackingurl) return null
-
   const status = last_delivery_status ? last_delivery_status.status : null
   return html`
     <div class="pl-box pl-action-box pl-box-pseudo-map">

--- a/src/js/components/actionbox/index.js
+++ b/src/js/components/actionbox/index.js
@@ -51,7 +51,7 @@ const ActionBox = (
       }
     }
 
-    if (type === 'pickup-location-unknown') {
+    if (type === 'pickup-location-unknown' && tHeader.courier && tHeader.courier.trackingurl) {
       result = [PickupLocationUnknown(tHeader, query.lang)]
     }
 


### PR DESCRIPTION
**Issue:**
When we get a tracking of "PickupLocationUnknown" state, there is this edge case we don't show anything if there is no courier tracking url available.

And for some carriers like "Clipper", they don't have a deeplink we can use, so this will always be empty. 

**Changes:**
- check for courier tracking url before showing the "PickupLocationUnknown" action box; if not, use the fallback one.

Before:
![Screenshot 2022-09-12 at 10 08 29](https://user-images.githubusercontent.com/25816956/189604154-d24f4b72-6665-4670-b933-40d6cc0830dd.png)

After:
![Screenshot 2022-09-12 at 10 08 20](https://user-images.githubusercontent.com/25816956/189604176-5b830198-4286-436b-b621-eaace3c57824.png)

Example:
https://hm.delivery-status.com/gb/en/?orderNo=45987023900&trackntrace&show_articleList=yes&selectedTrackingNo=HAM967024001669569HZ004001&s=DnIQ2BixTI

You can look for other examples using H&MUK, Clipper courier and "Click and Collect" orders.

[TT-174](https://parcellab.atlassian.net/browse/TT-174?atlOrigin=eyJpIjoiMmRkNDY3ZjI2NGI3NDJhOTk5NzlkNTZlODQ0NDQyZmEiLCJwIjoiaiJ9)
