### PR TITLE
REQ-115/bring-V4-up-to-date-with-translations

### DIFF
--- a/src/js/lib/static.js
+++ b/src/js/lib/static.js
@@ -6,6 +6,11 @@ const transitStates = {
     xmas_icon: 'christmas_gift',
     easter_icon: 'easter_order_processed'
   },
+  WarehousePrepared: {
+    icon: 'order_processed',
+    xmas_icon: 'christmas_gift',
+    easter_icon: 'easter_order_processed'
+  },
   Pending: {
     icon: 'order_processed',
     xmas_icon: 'christmas_gift',
@@ -97,6 +102,13 @@ const transitStates = {
     alert: 'success',
     easter_icon: 'easter_delivered'
   },
+  ReturnProcessed: {
+    icon: 'success_standard',
+    xmas_icon: 'christmas_tree',
+    color: '#58B957',
+    alert: 'success',
+    easter_icon: 'easter_delivered'
+  },
   Exception: {
     icon: 'warning_truck',
     color: '#DB524B',
@@ -119,14 +131,14 @@ const transitStates = {
     xmas_icon: 'christmas_sleigh',
     easter_icon: 'easter_info_truck'
   }
-}
+};
 
 const getIconName = (tStatus, theme) => {
-  const type = theme ? `${theme}_icon` : 'icon'
+  const type = theme ? `${theme}_icon` : 'icon';
   if (transitStates[tStatus]) {
-    return transitStates[tStatus][type] || transitStates[tStatus].icon
-  } else return transitStates.default[type] || transitStates.default.icon
-}
+    return transitStates[tStatus][type] || transitStates[tStatus].icon;
+  } else return transitStates.default[type] || transitStates.default.icon;
+};
 
 /* -------------------------------- Languages ------------------------------- */
 
@@ -245,25 +257,74 @@ const languages = {
     code: 'HUN',
     icon: 'https://cdn.parcellab.com/img/flags/hu.png'
   },
+  zh: {
+    name: 'zh',
+    label: '中文',
+    code: 'CHN',
+    icon: 'https://cdn.parcellab.com/img/flags/cn.png'
+  },
+  ko: {
+    name: 'ko',
+    label: '한국어',
+    code: 'KOR',
+    icon: 'https://cdn.parcellab.com/img/flags/kr.png'
+  },
+  tw: {
+    name: 'tw',
+    label: '台湾',
+    code: 'TWN',
+    icon: 'https://cdn.parcellab.com/img/flags/tw.png'
+  },
+  ja: {
+    name: 'ja',
+    label: '日本人',
+    code: 'JPN',
+    icon: 'https://cdn.parcellab.com/img/flags/jp.png'
+  },
   ru: {
     name: 'ru',
-    label: 'Русский',
+    label: 'русский',
     code: 'RUS',
     icon: 'https://cdn.parcellab.com/img/flags/ru.png'
   },
-  ja: {
-	  name: 'jp',
-	  label: '日本語',
-	  code: 'JPN',
-	  icon: 'https://cdn.parcellab.com/img/flags/jp.png'
-
+  tr: {
+    name: 'tr',
+    label: 'Türkçe',
+    code: 'TUR',
+    icon: 'https://cdn.parcellab.com/img/flags/tr.png'
+  },
+  ca: {
+    name: 'ca',
+    label: 'Català',
+    code: 'CAT',
+    icon: 'https://cdn.parcellab.com/img/flags/catalonia.png'
+  },
+  eu: {
+    name: 'eu',
+    label: 'Euskara',
+    code: 'EUS',
+    icon: 'https://cdn.parcellab.com/img/flags/basque.png'
+  },
+  gl: {
+    name: 'gl',
+    label: 'Galego',
+    code: 'GLG',
+    icon: 'https://cdn.parcellab.com/img/flags/galicia.png'
+  },
+  el: {
+    name: 'el',
+    label: 'Ελληνικά',
+    code: 'GRC',
+    icon: 'https://cdn.parcellab.com/img/flags/gr.png'
   }
-}
+};
 
 const translations = {
   en: {
+    'submit-btn': 'Search',
     delivery: 'Delivery',
     more: 'Show more...',
+    moreArticles: 'Show more...',
     orderNo: 'Order',
     predictions: {
       OutForDelivery: 'The package will arrive <b>today</b>.',
@@ -279,24 +340,28 @@ const translations = {
       'Friday',
       'Saturday'
     ],
-    alwaysOpened: 'Open 24 hours a day',
-    closesIn: 'Closes at',
-    opensIn: 'Opens at',
+    alwaysOpened: '24h opened',
+    closesIn: 'Closes in about',
+    opensIn: 'Opens in about',
+    openingHoursWarning: 'Opening hours may vary due to ###',
     error: {
-      delivery: 'We have not received your tracking information yet.',
-      search: 'We couldn\'t find any information for this delivery – please contact our Customer Service team.'
+      delivery: 'We have not yet received tracking data for your order.',
+      search: 'Unfortunately, no information was found for this delivery.'
     },
-    searchOrder: 'Search for your order',
+    searchOrder: 'Search order',
     zip: 'Zip code',
+    enterZipCode:
+      'Please enter your zip code to get access to all information.',
+    wrongZip: 'This zip code is wrong.',
     search: 'Search',
-    containsOf: 'includes',
+    containsOf: 'consists of',
     deliveries: 'deliveries',
-    showPickuplocation: 'Show collection location',
-    liveDelivery: 'Track your order',
+    showPickuplocation: 'Show pickup location',
+    liveDelivery: 'Live tracking',
     articleList: 'Items in this package',
     deliveryAddress: 'Delivery address',
     liveTrackingLastUpdate: 'Last update',
-    liveTrackingStationsNext: 'The driver\'s on his way to you.',
+    liveTrackingStationsNext: "The driver's on his way to you.",
     liveTrackingStation: '### stopover',
     liveTrackingStations: '### stopovers',
     liveTrackingCaption: 'until your shipment arrives.',
@@ -305,38 +370,42 @@ const translations = {
   },
   ru: {
     delivery: 'Доставка',
-    more: 'Показать больше',
+    more: 'Подробнее',
+    moreArticles: 'Подробнее',
     orderNo: 'Заказ',
     predictions: {
-      OutForDelivery: 'Посылку доставят <b>сегодня</b>.',
-      DestinationDeliveryCenter: 'Посылку доставят <b>завтра</b>.'
+      OutForDelivery: 'Посылка будет доставлена <b>сегодня</b>.',
+      DestinationDeliveryCenter: 'Посылка будет доставлена <b>завтра</b>.'
     },
     openingHours: 'Часы работы',
     openingHoursWarning: '',
     weekDays: [
+      'Воскресенье',
       'Понедельник',
       'Вторник',
       'Среда',
       'Четверг',
       'Пятница',
-      'Суббота',
-      'Воскресенье'
+      'Суббота'
     ],
     alwaysOpened: 'Открыто круглосуточно',
-    closesIn: 'Закрывается в',
-    opensIn: 'Открывается в',
+    closesIn: 'Закрывается через',
+    opensIn: 'Открывается через',
     error: {
-      delivery: 'Мы еще не получили информацию о заказе.',
-      search: 'Не удалось найти информацию об этом заказе. Пожалуйста, обратитесь в клиентскую службу.'
+      delivery: 'Мы еще не получили информацию о Вашем заказе.',
+      search: 'К сожалению, по данной доставке информация не найдена'
     },
     searchOrder: 'Поиск заказа',
     zip: 'Почтовый индекс',
     search: 'Искать',
-    containsOf: 'В этом заказе:',
+    enterZipCode:
+      'Введите Ваш почтовый индекс чтобы получить доступ ко всей информации.',
+    wrongZip: 'Этот почтовый индекс неправильный.',
+    containsOf: 'Состоит из',
     deliveries: 'Доставки',
-    showPickuplocation: 'Посмотреть адрес пункта',
-    liveDelivery: 'Отследить заказ',
-    articleList: 'Товары в посылке',
+    showPickuplocation: 'Пункт выдачи заказов',
+    liveDelivery: 'Отслеживание онлайн',
+    articleList: 'Артикулы в посылке',
     deliveryAddress: 'Адрес доставки',
     liveTrackingLastUpdate: '',
     liveTrackingStationsNext: '',
@@ -347,12 +416,14 @@ const translations = {
     liveTrackingPrediction: ''
   },
   de: {
-    delivery: 'Zustellung',
-    more: 'Mehr zeigen',
+    'submit-btn': 'Suchen',
+    delivery: 'Lieferung',
+    more: 'Mehr anzeigen...',
+    moreArticles: 'Mehr anzeigen...',
     orderNo: 'Bestellung',
     predictions: {
-      OutForDelivery: 'Ihr Paket kommt <b>heute</b>an',
-      DestinationDeliveryCenter: 'Ihr Paket kommt <b>morgen </b>an'
+      OutForDelivery: 'Die Ware wird noch <b>heute</b> geliefert.',
+      DestinationDeliveryCenter: 'Die Ware wird <b>morgen</b> geliefert.'
     },
     openingHours: 'Öffnungszeiten',
     weekDays: [
@@ -364,22 +435,27 @@ const translations = {
       'Freitag',
       'Samstag'
     ],
-    alwaysOpened: '24 Stunden geöffnet',
-    closesIn: 'Schließt um',
-    opensIn: 'Öffnet um',
+    alwaysOpened: 'Durchgehend geöffnet',
+    closesIn: 'Schließt in ungefähr',
+    opensIn: 'Öffnet in ungefähr',
+    openingHoursWarning: 'Öffnungszeiten können aufgrund von ### abweichen',
     error: {
-      delivery: 'Es sind noch keine Tracking-Informationen verfügbar',
-      search: 'Leider konnten wir für diese Sendung keine Informationen finden. Bitte wenden Sie sich an unseren Kundenservice'
+      delivery: 'Zu dieser Bestellung liegen noch keine Sendungsdaten vor.',
+      search:
+        'Leider liegen uns aktuell keine Sendungsdetails zu dieser Bestellung vor.'
     },
     searchOrder: 'Bestellung suchen',
-    zip: 'Postleitzahl',
+    zip: 'PLZ',
+    enterZipCode:
+      'Bitte gib deine PLZ ein, um Zugriff auf alle Informationen zu erhalten.',
+    wrongZip: 'Diese PLZ ist falsch.',
     search: 'Suchen',
-    containsOf: 'beinhaltet',
-    deliveries: 'Zustellungen',
+    containsOf: 'besteht aus',
+    deliveries: 'Lieferungen',
     showPickuplocation: 'Abholort anzeigen',
-    liveDelivery: 'Bestellung verfolgen',
+    liveDelivery: 'Live verfolgen',
     articleList: 'Artikel in diesem Paket',
-    deliveryAddress: 'Lieferadresse',
+    deliveryAddress: 'Zustelladresse',
     liveTrackingLastUpdate: 'Letzte Aktualisierung',
     liveTrackingStationsNext: 'Der Fahrer ist auf dem Weg zu dir.',
     liveTrackingStation: 'Noch ### Stopp vor dir',
@@ -389,8 +465,10 @@ const translations = {
     liveTrackingPrediction: 'Ankunftszeit ca.'
   },
   es: {
+    'submit-btn': 'Buscar',
     delivery: 'Entrega',
     more: 'Ver más...',
+    moreArticles: 'Ver más...',
     orderNo: 'Número de Orden',
     predictions: {
       OutForDelivery: 'El paquete llegará <b>Hoy</b>.',
@@ -409,27 +487,33 @@ const translations = {
     alwaysOpened: 'Abierto todo el día',
     closesIn: 'se cierra en',
     opensIn: 'abre en',
+    openingHoursWarning: 'Las horas de apertura pueden variar debido a ###',
     error: {
-      delivery: 'Actualmente no hay de datos de envío disponibles para este pedido.',
+      delivery:
+        'Actualmente no hay de datos de envío disponibles para este pedido.',
       search: 'Desafortunadamente tu paquete no esta disponible.'
     },
     searchOrder: 'Búsqueda del envío',
     search: 'Buscar',
     containsOf: 'consiste en',
     deliveries: 'entregas',
+    enterZipCode:
+      'Por favor, introduzca su código postal para tener acceso a toda la información.',
+    wrongZip: 'Este código postal está mal.',
     showPickuplocation: 'Lugar de recogida',
     articleList: 'Artículos en este paquete',
     deliveryAddress: 'Dirección de entrega'
   },
   fr: {
     delivery: 'Livraison',
-    more: 'Voir plus.',
+    more: 'Voir les étapes précédentes...',
+    moreArticles: 'Afficher plus...',
     orderNo: 'Commande',
     predictions: {
-      OutForDelivery: "Votre colis arrivera <b>aujourd'hui</b>.",
-      DestinationDeliveryCenter: 'Votre colis arrivera <b>demain</b>.'
+      OutForDelivery: "Le colis arrivera <b>aujourd'hui</b>.",
+      DestinationDeliveryCenter: 'Le colis arrivera <b>demain</b>.'
     },
-    openingHours: "Horaires d'ouverture",
+    openingHours: "Heures d'ouverture",
     weekDays: [
       'Dimanche',
       'Lundi',
@@ -439,26 +523,32 @@ const translations = {
       'Vendredi',
       'Samedi'
     ],
-    alwaysOpened: 'Ouvert 24h/24',
-    closesIn: 'ferme à',
-    opensIn: 'ouvre à',
+    alwaysOpened: 'Ouvert toute la journée',
+    closesIn: 'ferme dans',
+    opensIn: 'ouvre dans',
+    openingHoursWarning:
+      "Les heures d'ouverture peuvent varier en raison de ###",
     error: {
-      delivery: "Nous n'avons pas encore reçu vos informations de suivi.",
-      search: "Nous n'avons trouvé aucune information pour cette livraison - veuillez contacter notre équipe du Service client."
+      delivery:
+        "Aucune information concernant l'expédition disponible pour cette commande.",
+      search:
+        "Malheureusement, ce numéro de colis ou de commande n'est pas valide."
     },
-    searchOrder: 'Chercher ma commande',
-	zip: 'Code postal',
+    searchOrder: 'Rechercher la commande',
     search: 'Chercher',
-    containsOf: 'inclut',
+    containsOf: 'consiste en',
     deliveries: 'livraisons',
-	liveDelivery:'Suivre ma commande',
-    showPickuplocation: 'Afficher le lieu de collecte',
+    enterZipCode:
+      'Veuillez entrer votre code postal pour avoir accès à toutes les informations.',
+    wrongZip: 'Ce code postal est incorrect.',
+    showPickuplocation: 'Lieu de retrait',
     articleList: 'Articles dans ce colis',
     deliveryAddress: 'Adresse de livraison'
   },
   it: {
     delivery: 'Consegna',
     more: 'Mostra di più...',
+    moreArticles: 'Mostra di più...',
     orderNo: 'Numero ordine',
     predictions: {
       OutForDelivery: 'Il pacchetto arriverà <b>oggi</b>.',
@@ -477,14 +567,19 @@ const translations = {
     alwaysOpened: 'Aperto tutto il giorno',
     closesIn: 'chiude alle',
     opensIn: 'Apre alle',
+    openingHoursWarning: 'Gli orari di apertura possono variare a causa di ###',
     error: {
-      delivery: 'Non ci sono ancora informazioni sulla spedizione di questo ordine.',
+      delivery:
+        'Non ci sono ancora informazioni sulla spedizione di questo ordine.',
       search: 'Purtroppo non abbiamo dati per questa consegna.'
     },
     searchOrder: "cerca l'ordine",
     search: 'Ricerca',
     containsOf: 'consiste in',
     deliveries: 'consegne',
+    enterZipCode:
+      'Inserisci il tuo codice di avviamento postale per accedere a tutte le informazioni.',
+    wrongZip: 'Il codice postale è sbagliato.',
     showPickuplocation: 'Mostra punto di ritiro',
     articleList: 'Articoli in questo pacchetto',
     deliveryAddress: 'Indirizzo di consegna'
@@ -492,6 +587,7 @@ const translations = {
   nl: {
     delivery: 'Levering',
     more: 'Bekijk meer...',
+    moreArticles: 'Bekijk meer...',
     orderNo: 'Bestelling',
     predictions: {
       OutForDelivery: 'Het pakket zal <b>vandaag</b> aankomen.',
@@ -510,25 +606,31 @@ const translations = {
     alwaysOpened: 'De hele dag geopend',
     closesIn: 'Sluit over',
     opensIn: 'Opent over',
+    openingHoursWarning: 'De openingstijden kunnen variëren als gevolg van ###',
     error: {
-      delivery: 'Voor deze bestelling zijn nog geen track & trace gegevens bekend',
+      delivery:
+        'Voor deze bestelling zijn nog geen track & trace gegevens bekend',
       search: 'Helaas is de levering niet bekend.'
     },
     searchOrder: 'Zoek order',
     search: 'Zoeken',
     containsOf: 'bestaat uit',
     deliveries: 'leveringen',
+    enterZipCode:
+      'Voer uw postcode in om toegang te krijgen tot alle informatie.',
+    wrongZip: 'Deze postcode is fout.',
     showPickuplocation: 'Afhaalpunt',
     articleList: 'Items in dit pakket',
     deliveryAddress: 'Bezorgadres'
   },
   da: {
     delivery: 'Levering',
-    more: 'Vis mere',
+    more: 'Se mere...',
+    moreArticles: 'Se mere...',
     orderNo: 'Ordre',
     predictions: {
-      OutForDelivery: 'Din pakke ankommer <b>i dag</b>.',
-      DestinationDeliveryCenter: 'Din pakke ankommer <b>i morgen</b>.'
+      OutForDelivery: 'Pakken ankommer <b>i dag</b>.',
+      DestinationDeliveryCenter: 'Pakken ankommer <b>i morgen</b>.'
     },
     openingHours: 'Åbningstider',
     weekDays: [
@@ -540,30 +642,34 @@ const translations = {
       'Fredag',
       'Lørdag'
     ],
-    alwaysOpened: 'Åben 24 timer i døgnet',
-    closesIn: 'Lukker',
-    opensIn: 'Åbner',
+    alwaysOpened: 'Døgnåbent',
+    closesIn: 'Lukker om',
+    opensIn: 'Åbner om',
+    openingHoursWarning: 'Åbningstider kan variere på grund af ###',
     error: {
-      delivery: 'Vi har endnu ikke modtaget dine sporingsoplysninger.',
-      search: 'Vi kunne ikke finde nogen oplysninger om denne levering – kontakt venligst vores kundeservice-team.'
+      delivery:
+        'Der findes endnu ingen leveringsinformationer til denne bestilling.',
+      search: 'Beklageligvis er leveringen ikke tilgængelig.'
     },
-    searchOrder: 'Søg efter din ordre',
+    searchOrder: 'Søg ordre',
     search: 'Søg',
-	zip:'Postnummer',
-    containsOf: 'omfatter',
+    containsOf: 'består af',
     deliveries: 'leveringer',
-    showPickuplocation: 'Vis afhentningslokation',
-	liveDelivery: 'Spor din ordre',
-    articleList: 'Produkter i denne pakke',
+    enterZipCode:
+      'Indtast dit postnummer for at få adgang til alle oplysninger.',
+    wrongZip: 'Dette postnummer er forkert.',
+    showPickuplocation: 'Vis leveringssted',
+    articleList: 'Varer i denne pakke',
     deliveryAddress: 'Leveringsadresse'
   },
   sv: {
     delivery: 'Leverans',
-    more: 'Visa mer',
-    orderNo: 'Beställning:',
+    more: 'Se mer...',
+    moreArticles: 'Se mer...',
+    orderNo: 'Beställning',
     predictions: {
-      OutForDelivery: 'Ditt paket kommer att anlända <b>idag</b>.',
-      DestinationDeliveryCenter: 'Ditt paket kommer att anlända <b>imorgon</b>.'
+      OutForDelivery: 'Paketet kommer fram <b>i dag</b>.',
+      DestinationDeliveryCenter: 'Paketet kommer fram <b>i morgon</b>.'
     },
     openingHours: 'Öppettider',
     weekDays: [
@@ -575,26 +681,29 @@ const translations = {
       'Fredag',
       'Lörda'
     ],
-    alwaysOpened: 'Öppet dygnet runt',
-    closesIn: 'Stänger klockan',
-    opensIn: 'Öppnar klockan',
+    alwaysOpened: 'Öppet hela dagen',
+    closesIn: 'stänger om',
+    opensIn: 'öppnas om',
+    openingHoursWarning: 'Öppettiderna kan variera beroende på ###',
     error: {
-      delivery: 'Vi har inte tagit emot dina spårningsuppgifter än.',
-      search: 'Vi hittar ingen information om denna leverans – vänligen kontakta vårt kundtjänstteam.'
+      delivery: 'Beställningen har ännu inte tilldelats något kollinummer.',
+      search: 'Tyvärr är inte denna leverans tillgänglig.'
     },
-    searchOrder: 'Sök efter din beställning',
-	zip: 'Postnummer',
+    searchOrder: 'Sök order',
     search: 'Sök',
-    containsOf: 'inkluderar',
+    containsOf: 'består av',
     deliveries: 'leveranser',
-	liveDelivery: 'Spåra beställning',
-    showPickuplocation: 'Visa var du hittar upphämtningsstället',
-    articleList: 'Varor i detta paket',
+    enterZipCode:
+      'Ange ditt postnummer för att få tillgång till all information.',
+    wrongZip: 'Detta postnummer är fel.',
+    showPickuplocation: 'Visa leveranstid',
+    articleList: 'Detta paket innehåller',
     deliveryAddress: 'Leveransadress'
   },
   fi: {
     delivery: 'Toimitus',
     more: 'Katso lisää...',
+    moreArticles: 'Katso lisää...',
     orderNo: 'Tilaus',
     predictions: {
       OutForDelivery: 'Paketti saapuu <b>tänään</b>.',
@@ -613,6 +722,7 @@ const translations = {
     alwaysOpened: 'Avoinna koko päivän',
     closesIn: 'sulkeutuu',
     opensIn: 'avautuu',
+    openingHoursWarning: 'Käyttötunnit voivat vaihdella ### : n takia',
     error: {
       delivery: 'Tästä tilauksesta ei ole vielä lähetystietoja.',
       search: 'Valitettavasti tämä toimitus ei ole saatavilla järjestelmässä.'
@@ -621,6 +731,8 @@ const translations = {
     search: 'Hae',
     containsOf: 'koostuu',
     deliveries: 'toimituksesta',
+    enterZipCode: 'Anna postinumero, jotta pääset käsiksi kaikkiin tietoihin.',
+    wrongZip: 'Tämä postinumero on väärä.',
     showPickuplocation: 'Näytä noutopiste',
     articleList: 'Tuotteet tässä paketissa',
     deliveryAddress: 'Toimitusosoite'
@@ -628,6 +740,7 @@ const translations = {
   no: {
     delivery: 'Levering',
     more: 'Se mer...',
+    moreArticles: 'Se mer...',
     orderNo: 'Bestilling',
     predictions: {
       OutForDelivery: 'Pakken kommer fram <b>i dag</b>.',
@@ -646,56 +759,66 @@ const translations = {
     alwaysOpened: 'Åpent hele dagen',
     closesIn: 'stenger om',
     opensIn: 'åpner om',
+    openingHoursWarning: 'Driftstider kan variere på grunn av ###',
     error: {
-      delivery: 'Vi har ennå ikke mottatt sendingsopplysninger tilknyttet denne bestillingen.',
+      delivery:
+        'Vi har ennå ikke mottatt sendingsopplysninger tilknyttet denne bestillingen.',
       search: 'Dessverre er denne leveransen ikke tilgjengelig.'
     },
     searchOrder: 'Søk etter bestilling',
     search: 'Søk',
     containsOf: 'inneholder',
     deliveries: 'leveranser',
+    enterZipCode:
+      'Vennligst tast inn postnummeret ditt for å få tilgang til all informasjon.',
+    wrongZip: 'Postnummeret er feil.',
     showPickuplocation: 'vis hentested',
     articleList: 'Varer i denne pakken',
     deliveryAddress: 'Leveringsadresse'
   },
   pt: {
     delivery: 'Entrega',
-    more: 'Ver mais',
-    orderNo: 'Pedido',
+    more: 'Mostrar mais...',
+    moreArticles: 'Mostrar mais...',
+    orderNo: 'Encomenda',
     predictions: {
-      OutForDelivery: 'Seu pacote chegará <b>hoje</b>.',
-      DestinationDeliveryCenter: 'Seu pacote chegará <b>amanhã</b>.'
+      OutForDelivery: 'A encomenda chega <b>hoje</b>.',
+      DestinationDeliveryCenter: 'A encomenda chega <b>amanhã</b>.'
     },
-    openingHours: 'Horário de atendimento',
+    openingHours: 'Horário de abertura',
     weekDays: [
       'Domingo',
-      'Segunda-feira',
-      'Terça',
-      'quarta-feira',
-      'quinta-feira',
-      'Sexta-feira',
+      'Segunda feira',
+      'Terça feira',
+      'Quarta feira',
+      'Quinta feira',
+      'Sexta feira',
       'Sábado'
     ],
-    alwaysOpened: 'Aberto 24 horas por dia',
-    closesIn: 'fecha às',
-    opensIn: 'abre às',
+    alwaysOpened: 'Aberto 24h',
+    closesIn: 'fecha dentro de',
+    opensIn: 'Abre dentro de ',
+    openingHoursWarning: 'O horário de funcionamento pode variar devido ao ###',
     error: {
-      delivery: 'Ainda não recebemos suas informações de rastreamento.',
-      search: 'Não encontramos nenhuma informação para esta entrega. Por favor, entre em contato com o nosso time de Apoio ao cliente.'
+      delivery:
+        'Não foram ainda recebidos os dados de rastreamento do seu pedido.',
+      search:
+        'Infelizmente, nenhuma informação foi encontrada para esta entrega.'
     },
-    searchOrder: 'Procure seu pedido',
-    search: 'Procurar',
-	zip: 'CEP',
-    containsOf: 'inclui',
+    searchOrder: 'Procura de encomenda',
+    search: 'Procura',
+    containsOf: 'consiste em',
     deliveries: 'entregas',
-	liveDelivery: 'Acompanhe seu pedido',
-    showPickuplocation: 'Mostrar o local de retirada',
-    articleList: 'Itens neste pacote',
-    deliveryAddress: 'Endereço de entrega'
+    enterZipCode: 'Digite seu CEP para obter acesso a todas as informações.',
+    wrongZip: 'Este código postal está errado.',
+    showPickuplocation: 'Mostrar local de recolha',
+    articleList: 'Artigos nesta encomenda',
+    deliveryAddress: 'Morada de entrega'
   },
   pl: {
     delivery: 'Dostawa',
     more: 'Pokaż więcej...',
+    moreArticles: 'Pokaż więcej...',
     orderNo: 'Zamówienie',
     predictions: {
       OutForDelivery: 'Paczka zostanie doręczona jeszcze <b>dziś</b>.',
@@ -714,14 +837,19 @@ const translations = {
     alwaysOpened: 'Otwarte bez przerw',
     closesIn: 'zamyka za',
     opensIn: 'otwiera za',
+    openingHoursWarning: 'Godziny pracy mogą się różnić ze względu na ###',
     error: {
-      delivery: 'Nie wprowadzono jeszcze do systemu informacji o tej przesyłce.',
+      delivery:
+        'Nie wprowadzono jeszcze do systemu informacji o tej przesyłce.',
       search: 'Niestety, ta paczka nie znajduje się w systemie.'
     },
     searchOrder: 'szukaj zamówienia',
     search: 'Szukaj',
     containsOf: 'składa się z',
     deliveries: 'przesyłek',
+    enterZipCode:
+      'Wpisz kod pocztowy, aby uzyskać dostęp do wszystkich informacji.',
+    wrongZip: 'Ten kod pocztowy jest nieprawidłowy.',
     showPickuplocation: 'Pokaż punkt odbioru',
     articleList: 'Artykuły w tym pakiecie',
     deliveryAddress: 'Adres dostawy'
@@ -729,6 +857,7 @@ const translations = {
   ro: {
     delivery: 'Livrare',
     more: 'Arată mai multe...',
+    moreArticles: 'Arată mai multe...',
     orderNo: 'Comandă',
     predictions: {
       OutForDelivery: 'Pachetul va sosi <b>astăzi</b>.',
@@ -747,6 +876,7 @@ const translations = {
     alwaysOpened: 'Deschis toată ziua',
     closesIn: 'Se închide în',
     opensIn: 'Se va deschide',
+    openingHoursWarning: 'Orele de funcționare pot varia din cauza ###',
     error: {
       delivery: 'Din păcate, această livrare nu este disponibil.',
       search: 'Din păcate, această livrare nu este disponibil.'
@@ -755,6 +885,9 @@ const translations = {
     search: 'Căutare',
     containsOf: 'este format din',
     deliveries: 'livrări',
+    enterZipCode:
+      'Vă rugăm să introduceți codul poștal pentru a avea acces la toate informațiile.',
+    wrongZip: 'Acest cod poștal este greșit.',
     showPickuplocation: 'Noutopaikka',
     articleList: 'Articole din acest pachet',
     deliveryAddress: 'Adresă de livrare'
@@ -762,6 +895,7 @@ const translations = {
   cs: {
     delivery: 'Zásilka',
     more: 'Zobrazit více ...',
+    moreArticles: 'Zobrazit více ...',
     orderNo: 'Objednávka',
     predictions: {
       OutForDelivery: 'Zásilka bude doručena <b>dnes</b>.',
@@ -780,6 +914,7 @@ const translations = {
     alwaysOpened: 'Otevřeno 24 hod.',
     closesIn: 'Zavřeno od',
     opensIn: 'Otevřeno od',
+    openingHoursWarning: 'Provozní hodiny se mohou lišit v důsledku ###',
     error: {
       delivery: 'Je nám líto, ale tato zásilka není k dispozici.',
       search: 'Pro tuto zásilku nebyly nalezeny žádné informace.'
@@ -788,6 +923,9 @@ const translations = {
     search: 'Hledat',
     containsOf: 'Sestává z',
     deliveries: 'Zásilek',
+    enterZipCode:
+      'Chcete-li získat přístup ke všem informacím, zadejte své PSČ.',
+    wrongZip: 'Toto PSČ není správné.',
     showPickuplocation: 'Zobrazit místo odběru',
     articleList: 'Seznam zboží',
     deliveryAddress: 'Adresa doručení'
@@ -795,6 +933,7 @@ const translations = {
   sl: {
     delivery: 'Dostava',
     more: 'Podrobnosti...',
+    moreArticles: 'Podrobnosti...',
     orderNo: 'Naročilo',
     predictions: {
       OutForDelivery: 'Paket bo dostavljen še <b>danes</b>.',
@@ -813,15 +952,19 @@ const translations = {
     alwaysOpened: 'Odprto vse skozi',
     closesIn: 'Zapre se približno čez',
     opensIn: 'Odpre se približno čez',
+    openingHoursWarning: 'Ure delovanja se zaradi ### lahko razlikujejo',
     error: {
       delivery: 'Za to naročilo še ni na voljo številke za sledenje.',
-      search: 'Žal trenutni nimamo na voljo številke za sledenje za to naročilo.'
+      search:
+        'Žal trenutni nimamo na voljo številke za sledenje za to naročilo.'
     },
     searchOrder: 'Išči naročilo',
     zip: 'PTT',
     search: 'Išči',
     containsOf: 'je sestavljeno iz',
     deliveries: 'Dostava',
+    enterZipCode: 'Ta poštna številka je napačna.',
+    wrongZip: 'Ta poštna številka je napačna.',
     showPickuplocation: 'Prikaže kraj prevzema',
     liveDelivery: 'Sledenje v živo',
     articleList: 'Izdelek v tem paketu',
@@ -830,6 +973,7 @@ const translations = {
   hr: {
     delivery: 'Dostava',
     more: 'Prikaži više...',
+    moreArticles: 'Prikaži više...',
     orderNo: 'Narudžba',
     predictions: {
       OutForDelivery: 'Paket će biti dostavljen još <b>danas</b>.',
@@ -848,15 +992,20 @@ const translations = {
     alwaysOpened: 'Otvoreno cijeli dan',
     closesIn: 'Zatvara se otprilike u:',
     opensIn: 'Otvara se otprilike u:',
+    openingHoursWarning: 'Sati rada mogu varirati zbog ###',
     error: {
       delivery: 'Ova narudžba još nema broja za online pračenje pošiljke.',
-      search: 'Nažalost, trenutno broj za online pračenje pošiljke nije dostupan.'
+      search:
+        'Nažalost, trenutno broj za online pračenje pošiljke nije dostupan.'
     },
     searchOrder: 'Traži narudžbu',
     zip: 'Poštanski broj',
     search: 'Traži',
     containsOf: 'sastoji se od',
     deliveries: 'Dostava',
+    enterZipCode:
+      'Unesite svoj poštanski broj da biste pristupili svim podacima.',
+    wrongZip: 'Ovaj poštanski broj nije u redu.',
     showPickuplocation: 'Prikaz lokacije preuzimanja',
     liveDelivery: 'Online pračenje',
     articleList: 'Proizvodi u ovom paketu',
@@ -865,6 +1014,7 @@ const translations = {
   bg: {
     delivery: 'Доставка',
     more: 'Научи повече...',
+    moreArticles: 'Научи повече...',
     orderNo: 'Поръчка',
     predictions: {
       OutForDelivery: 'Стоките ще бъдат доставени още <b>днес</b>.',
@@ -883,15 +1033,20 @@ const translations = {
     alwaysOpened: 'Без почивен ден',
     closesIn: 'Затваря след около',
     opensIn: 'Отваря след около',
+    openingHoursWarning: 'Часовете на работа може да варират поради ###',
     error: {
       delivery: 'Все още няма данни за пратката към тази поръчка.',
-      search: 'За съжаление, в момента още нямаме данни за пратката към тази поръчка.'
+      search:
+        'За съжаление, в момента още нямаме данни за пратката към тази поръчка.'
     },
     searchOrder: 'Намери поръчка',
     zip: 'Пощ. код',
     search: 'Търсене',
     containsOf: 'състои се от',
     deliveries: 'Доставки',
+    enterZipCode:
+      'Моля, въведете пощенския си код, за да получите достъп до цялата информация.',
+    wrongZip: 'Този пощенски код е грешен.',
     showPickuplocation: 'Показване на места за взимане',
     liveDelivery: 'Проследи на живо',
     articleList: 'Продукти в този пакет',
@@ -900,6 +1055,7 @@ const translations = {
   sk: {
     delivery: 'Doprava',
     more: 'Podrobnosti',
+    moreArticles: 'Podrobnosti',
     orderNo: 'Objednávka',
     predictions: {
       OutForDelivery: 'Balík bude doručený <b>dnes</b>.',
@@ -918,8 +1074,10 @@ const translations = {
     alwaysOpened: 'Otvorené 24h',
     closesIn: 'Zatvára sa o',
     opensIn: 'Otvára sa o',
+    openingHoursWarning: 'Prevádzkové hodiny sa môžu líšiť v dôsledku ###',
     error: {
-      delivery: 'Žiaľ doposiaľ sme neobdržali dáta na sledovanie Vašej objednávky.',
+      delivery:
+        'Žiaľ doposiaľ sme neobdržali dáta na sledovanie Vašej objednávky.',
       search: 'Bohužiaľ, k zadanej objednávke neboli nájdené žiadne informacie.'
     },
     searchOrder: 'Vyhľadať objednávku',
@@ -927,6 +1085,9 @@ const translations = {
     search: 'Hľadať',
     containsOf: 'Pozostáva z',
     deliveries: 'Expedovaný tovar',
+    enterZipCode:
+      'Ak chcete získať prístup ku všetkým informáciám, zadajte svoje PSČ.',
+    wrongZip: 'Toto PSČ je nesprávne.',
     showPickuplocation: 'Ukáž miesto prevzatia',
     liveDelivery: 'Live sledovanie',
     articleList: 'Produkty v tomto balíku',
@@ -935,10 +1096,12 @@ const translations = {
   hu: {
     delivery: 'Szállítás',
     more: 'További információk...',
+    moreArticles: 'További információk...',
     orderNo: 'Rendelés',
     predictions: {
       OutForDelivery: 'A rendelés még a <b>mai napon</b> kiszállításra kerül.',
-      DestinationDeliveryCenter: 'A rendelés a <b>holnapi napon</b> kerül kiszállításra.'
+      DestinationDeliveryCenter:
+        'A rendelés a <b>holnapi napon</b> kerül kiszállításra.'
     },
     openingHours: 'Nyitvatartási idő',
     weekDays: [
@@ -953,27 +1116,146 @@ const translations = {
     alwaysOpened: 'Folyamatosan nyitva',
     closesIn: 'Zárás körübelül',
     opensIn: 'Nyitás körübelül',
+    openingHoursWarning: 'A működési idő a ### miatt változhat',
     error: {
-      delivery: 'Ehhez a rendeléshez még nem állnak rendelkezésre szállítási adatok.',
-      search: 'Sajnos ehhez a rendeléshez még nem állnak rendelkezésre szállítási adatok.'
+      delivery:
+        'Ehhez a rendeléshez még nem állnak rendelkezésre szállítási adatok.',
+      search:
+        'Sajnos ehhez a rendeléshez még nem állnak rendelkezésre szállítási adatok.'
     },
     searchOrder: 'Rendelés keresése',
     zip: 'Irányítószám',
     search: 'Keresés',
     containsOf: 'tartalmaz',
     deliveries: 'küldemény',
+    enterZipCode:
+      'Kérjük, adja meg irányítószámát, hogy minden információhoz hozzáférjen.',
+    wrongZip: 'Ez a irányítószám nem megfelelő.',
     showPickuplocation: 'Felvételi hely mutatása',
     liveDelivery: 'Élő követés',
     articleList: 'Ebben a csomagban található termékek',
     deliveryAddress: 'Szállítási cím'
   },
-  ja: {
+  zh: {
     delivery: '配送',
-    more: '詳細を見る',
-    orderNo: 'ご注文',
+    more: '显示更多...',
+    moreArticles: '显示更多...',
+    orderNo: '订单',
     predictions: {
-      OutForDelivery: 'ご注文の商品は<b>本日お届け予定です</b>',
-      DestinationDeliveryCenter: 'ご注文の商品は<b>明日お届け予定です</b>'
+      OutForDelivery: '包裹将在今天<b></ b>到达。',
+      DestinationDeliveryCenter: '包裹将在明天<b></ b>到达。'
+    },
+    openingHours: '营业时间',
+    weekDays: [
+      '星期日',
+      '星期一',
+      '星期二',
+      '星期三',
+      '星期四',
+      '星期五',
+      '星期六'
+    ],
+    alwaysOpened: '24小时营业',
+    closesIn: '关闭大约在',
+    opensIn: '开始营业大约在',
+    error: {
+      delivery: '我们尚未收到您订单的跟踪数据。',
+      search: '很遗憾，我们找不到此次配送的信息。'
+    },
+    searchOrder: '搜索订单',
+    zip: '邮政编码',
+    search: '搜索',
+    enterZipCode: '请输入你的邮政编码，以获得所有信息。',
+    wrongZip: '这个邮政编码是错误的。',
+    containsOf: '由**组成',
+    deliveries: '配送',
+    showPickuplocation: '显示取货地点',
+    liveDelivery: '实时追踪',
+    articleList: '此包装中的文章',
+    deliveryAddress: '邮寄地址'
+  },
+  ko: {
+    delivery: '배송',
+    more: '추가',
+    moreArticles: '추가',
+    orderNo: '주문 번호',
+    predictions: {
+      OutForDelivery: '소포는 <b>금일</b>. 도착예정입니다.',
+      DestinationDeliveryCenter: '소포는 <b>내일</b>. 도착 예정입니다.'
+    },
+    openingHours: '영업 시간',
+    weekDays: [
+      '일요일',
+      '월요일',
+      '화요일',
+      '수요일',
+      '목요일',
+      '금요일',
+      '토요일'
+    ],
+    alwaysOpened: '24시간 영업',
+    closesIn: '영업 종료',
+    opensIn: '영업 개시',
+    error: {
+      delivery: '고객님 배송 정보를 아직 받지 못했습니다.',
+      search: '안타깝게도 이 배송건에 관련된 정보가 확인되지 않습니다.'
+    },
+    searchOrder: '주문 검색',
+    zip: '우편번호',
+    search: '검색',
+    enterZipCode: '모든 정보에 액세스하려면 우편 번호를 입력하십시오.',
+    wrongZip: '우편번호가 잘못되었습니다.',
+    containsOf: '~로 구성되다',
+    deliveries: '배송',
+    showPickuplocation: '배송 픽업 장소 확인',
+    liveDelivery: '실시간 배송 조회',
+    articleList: '소포 내 항복',
+    deliveryAddress: '배송 주소'
+  },
+  tw: {
+    delivery: '配送',
+    more: '顯示更多...',
+    moreArticles: '顯示更多...',
+    orderNo: '訂單',
+    predictions: {
+      OutForDelivery: '包裹將在今天<b></ b>到達。',
+      DestinationDeliveryCenter: '包裹將在明天<b></ b>到達。'
+    },
+    openingHours: '營業時間',
+    weekDays: [
+      '星期日',
+      '星期一',
+      '星期二',
+      '星期三',
+      '星期四',
+      '星期五',
+      '星期六'
+    ],
+    alwaysOpened: '24小時營業',
+    closesIn: '關閉大約在',
+    opensIn: '開始營業大約在',
+    error: {
+      delivery: '我們尚未收到您訂單的跟踪數據。',
+      search: '很遺憾，我們找不到此次配送的信息。'
+    },
+    searchOrder: '搜索訂單',
+    zip: '郵政編碼',
+    search: '搜索',
+    containsOf: '由**組成',
+    deliveries: '配送',
+    showPickuplocation: '顯示取貨地點',
+    liveDelivery: '實時追踪',
+    articleList: '此包裝中的文章',
+    deliveryAddress: '郵寄地址'
+  },
+  ja: {
+    delivery: '配達',
+    more: 'さらに表示する...',
+    moreArticles: 'さらに表示する...',
+    orderNo: '注文',
+    predictions: {
+      OutForDelivery: '小包は<b>今日</ b>到着します。',
+      DestinationDeliveryCenter: '小包は<b>明日</ b>到着します。'
     },
     openingHours: '営業時間',
     weekDays: [
@@ -986,27 +1268,242 @@ const translations = {
       '土曜日'
     ],
     alwaysOpened: '24時間営業',
-    closesIn: '閉店',
-    opensIn: '開店',
+    closesIn: 'もうすぐ閉まります',
+    opensIn: 'もうすぐ開きます',
     error: {
-      delivery: '追跡情報を確認中です.',
-      search: 'この配送について情報を表示できません。お手数ですが、カスタマーサービスまでお問い合わせいただきますようお願いいたします.'
+      delivery: 'ご注文の追跡情報をまだ受け取っていません。',
+      search: '残念ながら、この配送に関する情報は見つかりませんでした。'
     },
-    searchOrder: 'ご注文を検索',
+    searchOrder: 'ご注文検索',
     zip: '郵便番号',
     search: '検索',
-    containsOf: '含む',
+    enterZipCode:
+      '全ての情報にアクセスするためには、郵便番号を入力してください',
+    wrongZip: 'この郵便番号は間違っています。',
+    containsOf: 'からなる',
     deliveries: '配送',
-    showPickuplocation: '集荷先住所を見る',
-    liveDelivery: 'ご注文の追跡',
-    articleList: 'この荷物に含まれる商品',
+    showPickuplocation: '受け取り場所を表示',
+    liveDelivery: 'ライブ追跡',
+    articleList: '小包の中の品物',
     deliveryAddress: 'お届け先住所'
+  },
+  tr: {
+    delivery: 'Gönderi Kodu',
+    more: 'Daha fazla göster…',
+    moreArticles: 'Daha fazla göster…',
+    orderNo: 'Sipariş Numarası',
+    predictions: {
+      OutForDelivery: 'Teslimat <b>bugün</b> gönderilecek.',
+      DestinationDeliveryCenter: 'Teslimat <b>yarın</b> gönderilecek.'
+    },
+    openingHours: 'açılış saatleri',
+    openingHoursWarning: '###',
+    weekDays: [
+      'Pazar',
+      'Pazartesi',
+      'Sali',
+      'Carsamba',
+      'Persembe',
+      'Cuma',
+      'Cumartesi'
+    ],
+    alwaysOpened: '24 saat acik',
+    closesIn: 'civarinda kapanir',
+    opensIn: 'civarinda acilir',
+    error: {
+      delivery: 'Siparişiniz için henüz takip verisi almadık.',
+      search: 'Maalesef bu teslimat için hiçbir bilgi bulunamadı.'
+    },
+    searchOrder: 'Sipariş ara',
+    zip: 'Posta kodu',
+    search: 'Ara',
+    enterZipCode: 'Tüm bilgilere erişmek için lütfen posta kodunuzu girin.',
+    wrongZip: 'Bu posta kodu yanlış.',
+    containsOf: 'içerir',
+    deliveries: 'Iletimler',
+    showPickuplocation: 'Alma yerini göster',
+    liveDelivery: 'Canli takip et',
+    articleList: 'Paketin icindeki ürünler',
+    deliveryAddress: 'Iletim Adresi',
+    liveTrackingLastUpdate: '',
+    liveTrackingStationsNext: '',
+    liveTrackingStation: '',
+    liveTrackingStations: '',
+    liveTrackingCaption: '',
+    liveTrackingCaptionNext: '',
+    liveTrackingPrediction: ''
+  },
+  ca: {
+    delivery: 'Lliurament',
+    more: 'Mostra més...',
+    moreArticles: 'Mostra més...',
+    orderNo: 'Número de comanda',
+    predictions: {
+      OutForDelivery: 'El paquet arribarà <b>avui</b>.',
+      DestinationDeliveryCenter: 'El paquet arribarà <b>demà</b>.'
+    },
+    openingHours: 'Horari d´obertura',
+    weekDays: [
+      'Diumenge',
+      'Dilluns',
+      'Dimarts',
+      'Dimecres',
+      'Dijous',
+      'Divendres',
+      'Dissabte'
+    ],
+    alwaysOpened: 'Obert tot el dia',
+    closesIn: 'es tanca en',
+    opensIn: 'obre en',
+    openingHoursWarning: 'L´horari d´obertura pot variar a causa de ###',
+    error: {
+      delivery:
+        'Actualment no hi ha de dades d´enviament disponibles per a aquesta comanda.',
+      search: 'Malauradament, el teu paquet no està disponible.'
+    },
+    searchOrder: 'Cerca de l´enviament',
+    search: 'Cerca',
+    containsOf: 'consisteix en',
+    deliveries: 'lliuraments',
+    enterZipCode:
+      'Si us plau, introdueix el teu codi postal per poder accedir a tota la informació.',
+    wrongZip: 'Aquest codi postal no és correcte.',
+    showPickuplocation: 'Lloc de recollida',
+    articleList: 'Articles d´aquest paquet',
+    deliveryAddress: 'Adreça de lliurament'
+  },
+  eu: {
+    delivery: 'Entrega',
+    more: 'Ikusi gehiago...',
+    moreArticles: 'Ikusi gehiago...',
+    orderNo: 'Eskaera-zenbakia',
+    predictions: {
+      OutForDelivery: 'Paketea <b>Gaur</b> iritsiko da.',
+      DestinationDeliveryCenter: 'Paketea <b>Bihar</b> iritsiko da.'
+    },
+    openingHours: 'Ordutegia',
+    weekDays: [
+      'Igandea',
+      'Astelehena',
+      'Asteartea',
+      'Asteazkena',
+      'Osteguna',
+      'Ostirala',
+      'Larunbata'
+    ],
+    alwaysOpened: 'Egun osoan zehar irekita',
+    closesIn: 'itxiera-ordua:',
+    opensIn: 'irekiera-ordua:',
+    openingHoursWarning: 'Irekiera-orduak aldatu daitezke ### dela eta.',
+    error: {
+      delivery:
+        'Une honetan ez dago eskaera honentzako bidalketa-daturik eskuragarri.',
+      search: 'Zoritxarrez, zure paketea ez dago eskuragarri.'
+    },
+    searchOrder: 'Bidalketaren bilaketa',
+    search: 'Bilatu',
+    containsOf: 'datza',
+    deliveries: 'entregak',
+    enterZipCode:
+      'Sartu zure posta-kodea informazio guztia atzitu ahal izateko.',
+    wrongZip: 'Posta-kode hau ez da zuzena.',
+    showPickuplocation: 'Jasotzeko lekua',
+    articleList: 'Pakete honetako artikuluak',
+    deliveryAddress: 'Entrega-helbidea'
+  },
+  gl: {
+    delivery: 'Entrega',
+    more: 'Ver máis...',
+    moreArticles: 'Ver máis...',
+    orderNo: 'Número de pedido',
+    predictions: {
+      OutForDelivery: 'O paquete chegará <b>hoxe</b>.',
+      DestinationDeliveryCenter: 'O paquete chegará <b>mañá</b>.'
+    },
+    openingHours: 'Horario de apertura',
+    weekDays: [
+      'Domingo',
+      'Luns',
+      'Martes',
+      'Mércores',
+      'Xoves',
+      'Venres',
+      'Sábado'
+    ],
+    alwaysOpened: 'Aberto todo o día',
+    closesIn: 'pecha en',
+    opensIn: 'abre en',
+    openingHoursWarning: 'As horas de apertura poden variar debido a ###',
+    error: {
+      delivery:
+        'Nestes momentos non hai datos de envío dispoñibles para este pedido.',
+      search: 'Sentímolo, o teu paquete non está dispoñible.'
+    },
+    searchOrder: 'Búsqueda do envío',
+    search: 'Buscar',
+    containsOf: 'consiste en',
+    deliveries: 'entregas',
+    enterZipCode:
+      'Introduce o teu código postal para ter acceso a toda a información.',
+    wrongZip: 'Este código postal está mal.',
+    showPickuplocation: 'Lugar de recollida',
+    articleList: 'Artigos neste paquete',
+    deliveryAddress: 'Enderezo de entrega'
+  },
+  el: {
+    'submit-btn': 'Αναζήτηση',
+    delivery: 'Παράδοση',
+    more: 'Δείτε περισσότερα...',
+    moreArticles: 'Δείτε περισσότερα...',
+    orderNo: 'Παραγγελία',
+    predictions: {
+      OutForDelivery: 'Το πακέτο θα φτάσει <b>σήμερα</b>.',
+      DestinationDeliveryCenter: 'Το πακέτο θα φτάσει <b>αύριο</b>.'
+    },
+    openingHours: 'Ώρες λειτουργίας',
+    weekDays: [
+      'Κυριακή',
+      'Δευτέρα',
+      'Τρίτη',
+      'Τετάρτη',
+      'Πέμπτη',
+      'Παρασκευή',
+      'Σάββατο'
+    ],
+    alwaysOpened: 'Ανοικτό 24 ώρες',
+    closesIn: 'Κλείνει σε περίπου',
+    opensIn: 'Ανοίγει σε περίπου',
+    openingHoursWarning: 'Οι ώρες λειτουργίας ενδέχεται να διαφέρουν λόγω ###',
+    error: {
+      delivery:
+        'Δεν έχουμε λάβει ακόμη δεδομένα παρακολούθησης για την παραγγελία σας.',
+      search: 'Δυστυχώς, δεν βρέθηκαν πληροφορίες για την παράδοση αυτή.'
+    },
+    searchOrder: 'Παραγγελία αναζήτησης',
+    zip: 'TK',
+    enterZipCode:
+      'Εισάγετε την TK σας για να αποκτήσετε πρόσβαση σε όλες τις πληροφορίες.',
+    wrongZip: 'Αυτή η TK είναι λάθος.',
+    search: 'Αναζήτηση',
+    containsOf: 'αποτελείται από',
+    deliveries: 'παραδόσεις',
+    showPickuplocation: 'Εμφάνιση τοποθεσίας παραλαβής',
+    liveDelivery: 'Ζωντανή παρακολούθηση',
+    articleList: 'Στοιχεία σε αυτό το πακέτο',
+    deliveryAddress: 'Διεύθυνση παράδοσης',
+    liveTrackingLastUpdate: 'Τελευταία ενημέρωση',
+    liveTrackingStationsNext: "Ο οδηγός είναι καθ' οδόν προς εσάς.",
+    liveTrackingStation: '### ενδιάμεση στάση',
+    liveTrackingStations: '### στάσεις',
+    liveTrackingCaption: 'μέχρι να φτάσει η αποστολή σας.',
+    liveTrackingCaptionNext: 'Είστε ο επόμενος ενδιάμεσος σταθμός.',
+    liveTrackingPrediction: 'Χρόνος άφιξης περίπου.'
   }
-}
+};
 
 module.exports = {
   translations,
   languages,
   transitStates,
   getIconName
-}
+};


### PR DESCRIPTION
**Description:**
V4 is a branch of a very old version of V3, which does not support all the languages and uses it outdated language codes.

Bringing this version up to date with the V3 is possible, but the number of unexpected changes that could appear to the UI, that the vendor might not be happy about, might be too many. So I updated just the necessary part.

**Changes:**
This PR updates the languages and its translations.

PS: I kept the country names out as this logic is not present in this version of the plugin and it could make the PR cleaner to review.

**How to test:**
You can run in your local the repo farfetch.delivery-status.com and the js plugin with this branch.

Make sure that the farfetch.delivery-status.com on your local looks instead for the local js / css files being served.

Test the urls
http://localhost:3000/src/?locale=jp-ja&orderNo=ZD8D5H&show_articleList=yes&selectedTrackingNo=9579297965&s=yeHJzLTnft&lang=ja

http://localhost:3000/src/?locale=ko-ko&orderNo=ZD8D5H&show_articleList=yes&selectedTrackingNo=9579297965&s=yeHJzLTnft&lang=ko
