### PR TITLE
update-v4-deploy-script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ deploy:
 	@echo '🤖  Deploying this v4 stuff! ';
 	aws s3 cp ./dist/index.css s3://parcellab-cdn/css/v4/parcelLab.min.css --cache-control max-age=86400;
 	aws s3 cp ./dist/index.js s3://parcellab-cdn/js/v4/parcelLab.min.js --cache-control max-age=86400;
-	cf-invalidate E3R5S2BJQI4RDS css/v4/parcelLab.min.css js/v4/parcelLab.min.js;
+	aws cloudfront create-invalidation --distribution-id E3R5S2BJQI4RDS --paths "/css/v4/parcelLab.min.css" "/js/v4/parcelLab.min.js";
 	@echo '🕶  Deployed files! Deal with it...';


### PR DESCRIPTION
V4 is an old snapshot of our current V3 plugin. 

But given we're still using it, I'm just updating the script that I had to use to re-deploy the plugin for the Farfetch store to use.