### PR TITLE
feat: allow &selectedTrackingNo= to target tracking id (REQ-730)

### DIFF
--- a/src/js/parcelLab.js
+++ b/src/js/parcelLab.js
@@ -357,7 +357,10 @@ class ParcelLab {
     if (selectedTrackingNo && header) {
       for (let i = 0; i < header.length; i++) {
         const elem = header[i]
-        if (elem.tracking_number === selectedTrackingNo) {
+        if (
+          elem.tracking_number === selectedTrackingNo ||
+          elem.id === selectedTrackingNo
+        ) {
           selectedTrackingIndex = i
         }
       }


### PR DESCRIPTION
Addresses https://parcellab.atlassian.net/browse/REQ-730

---

parcelLab tracking ids do not conflict with tracking numbers of any carrier due to their format. We can therefore reuse the existing URL search param `&selectedTrackingNo=` to not only target via `header.tracking_number`, but also via `tracking.id`.

Benefit of this change is the ability to target trackings during the pre-dispatch part of their lifecycle when no tracking number has been assigned yet.