### PR TITLE
fix: resolve Dependabot js-yaml DoS alert (#124)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "9.39.2",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
@@ -569,7 +592,6 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -2446,7 +2468,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2605,7 +2626,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2886,7 +2906,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3319,19 +3338,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "overrides": {
     "immutable": ">=5.1.5",
     "minimatch": ">=3.1.3",
-    "picomatch": ">=4.0.4"
+    "picomatch": ">=4.0.4",
+    "js-yaml": "^4.2.0"
   },
   "dependencies": {
     "cash-dom": "^1.3.4",


### PR DESCRIPTION
## What

Resolves the open Dependabot alert **[#124](https://github.com/parcelLab/parcelLab-js-plugin/security/dependabot/124)** — *JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases* (medium, dev dependency).

## How

`js-yaml` is pulled in transitively (`@eslint/eslintrc` → `eslint`) and was pinned at the vulnerable `4.1.1`. Added an `overrides` entry pinned to `^4.2.0`, bumping it to **4.3.0** (patched).

```diff
   "overrides": {
     "immutable": ">=5.1.5",
     "minimatch": ">=3.1.3",
-    "picomatch": ">=4.0.4"
+    "picomatch": ">=4.0.4",
+    "js-yaml": "^4.2.0"
   },
```

This follows the existing `overrides` convention used for prior Dependabot fixes (immutable, minimatch, picomatch in #119/#120).

### Why `^4.2.0` and not `>=4.2.0`
`>=4.2.0` made npm resolve `js-yaml` to **5.2.0** — a major bump that breaks the 4.x API `@eslint/eslintrc` (`js-yaml: "^4.1.1"`) expects. Constraining to `^4.2.0` keeps it on the 4.x line and resolves to 4.3.0.

## Validation

- `package-lock.json` diff: only functional change is `js-yaml` `4.1.1` → `4.3.0`.
- `npx eslint` runs successfully with 4.3.0 (eslint reads its config via js-yaml) — no breakage.
- CI (`deploy.yml`) only runs install + `parcel build`; neither is affected by this dev-dependency bump.

## Out of scope (FYI)

`npm audit` separately flags `brace-expansion@5.0.5` (moderate DoS, GHSA-jxxr-4gwj-5jf2). It is **already on `main`**, was **not** introduced here, and is **not** currently a Dependabot alert. Left out to keep this PR scoped to the open alert — happy to do a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)