### PR TITLE
fix: resolve Dependabot security alerts for immutable and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2588,16 +2588,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -3235,9 +3235,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -55,10 +55,11 @@
     "sass": "^1.83.4"
   },
   "overrides": {
-    "immutable": ">=5.1.5",
+    "immutable": ">=5.1.8",
     "minimatch": ">=3.1.3",
     "picomatch": ">=4.0.4",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "brace-expansion": ">=5.0.8"
   },
   "dependencies": {
     "cash-dom": "^1.3.4",


### PR DESCRIPTION
## Summary

Closes the three open high-severity Dependabot alerts on this repo by bumping the `immutable` override and adding a `brace-expansion` override.

| Alert | Package | Severity | Was | Now |
|---|---|---|---|---|
| [#127](https://github.com/parcelLab/parcelLab-js-plugin/security/dependabot/127) | `immutable` | high | 5.1.5 | 5.1.9 |
| [#126](https://github.com/parcelLab/parcelLab-js-plugin/security/dependabot/126) | `immutable` | high | 5.1.5 | 5.1.9 |
| [#125](https://github.com/parcelLab/parcelLab-js-plugin/security/dependabot/125) | `brace-expansion` | high | 5.0.5 | 5.0.8 |

- **#127** — hash-collision algorithmic complexity DoS in `Immutable.Map`/`Set`
- **#126** — `Immutable.List` 32-bit trie overflow leading to unrecoverable DoS
- **#125** — DoS via exponential-time expansion of consecutive non-expanding `{}` groups

## Note on the brace-expansion version

The override is `>=5.0.8`, not the `>=5.0.7` that alert #125 asks for. A second advisory — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), unbounded expansion causing an OOM process crash — covers `<=5.0.7`. Resolving to 5.0.7 leaves five high-severity findings in `npm audit`; 5.0.8 clears all of them.

5.0.8 was published 2026-07-23, so it is 4 days old at time of writing — short of the 7-day package-age cooldown. This was accepted deliberately: it is the only version that closes both advisories, and the exposure is dev-tooling only (see below).

## Impact

Both packages are **dev-only transitive dependencies** and do not reach the shipped browser bundle:

- `eslint` → `minimatch` → `brace-expansion`
- `sass` → `immutable`

The lockfile diff touches exactly these two packages — no other resolutions drifted.

## Verification

- `npm audit` → **0 vulnerabilities** (was 5 high on the intermediate 5.0.7 attempt)
- `npm ci` → clean install from the updated lockfile
- `npm run bundle` → builds successfully; `bundle/index.js` 256.02 kB, `bundle/index.css` 50.22 kB (byte-identical to `main`)

### Pre-existing issue, not addressed here

`npm run lint` fails on this branch **and on `main`** with `SyntaxError: The requested module 'minimatch' does not provide an export named 'default'`. The existing `"minimatch": ">=3.1.3"` override (from b039cd9) resolves minimatch to 10.x, which is ESM-only, while `@eslint/eslintrc` expects the CJS 3.x default export. CI does not run lint (`.github/workflows/deploy.yml` only runs `npm ci` + build), so nothing is newly broken — but it is worth a separate fix.